### PR TITLE
Update release docs with info about k_bundle creation

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -68,7 +68,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.5.0
+          image: dhub.c2.croc.ru/kaas/csi-provisioner:v1.3.0
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -82,7 +82,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.2.0
+          image: dhub.c2.croc.ru/kaas/csi-attacher:v1.2.0
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -95,7 +95,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: dhub.c2.croc.ru/kaas/livenessprobe:v1.1.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -55,7 +55,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: dhub.c2.croc.ru/kaas/csi-node-driver-registrar:v1.1.0
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -75,7 +75,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: dhub.c2.croc.ru/kaas/livenessprobe:v1.1.0
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/deploy/kubernetes/overlays/stable/k_bundle.yaml
+++ b/deploy/kubernetes/overlays/stable/k_bundle.yaml
@@ -193,7 +193,7 @@ spec:
               key: access_key
               name: aws-secret
               optional: true
-        image: dhub.c2.croc.ru/kaas/aws-ebs-csi-driver:v0.5.0
+        image: dhub.c2.croc.ru/kaas/aws-ebs-csi-driver:v0.5.0-CROC1
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -279,7 +279,7 @@ spec:
           value: unix:/csi/csi.sock
         - name: AWS_REGION
           value: croc
-        image: dhub.c2.croc.ru/kaas/aws-ebs-csi-driver:v0.5.0
+        image: dhub.c2.croc.ru/kaas/aws-ebs-csi-driver:v0.5.0-CROC1
         livenessProbe:
           failureThreshold: 5
           httpGet:

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -4,13 +4,13 @@ bases:
 - ../../base
 images:
 - name: dhub.c2.croc.ru/kaas/aws-ebs-csi-driver
-  newTag: v0.5.0
-- name: quay.io/k8scsi/csi-provisioner
+  newTag: v0.5.0-CROC1
+- name: dhub.c2.croc.ru/kaas/csi-provisioner
   newTag: v1.3.0
-- name: quay.io/k8scsi/csi-attacher
+- name: dhub.c2.croc.ru/kaas/csi-attacher
   newTag: v1.2.0
-- name: quay.io/k8scsi/livenessprobe
+- name: dhub.c2.croc.ru/kaas/livenessprobe
   newTag: v1.1.0
-- name: quay.io/k8scsi/csi-node-driver-registrar
+- name: dhub.c2.croc.ru/kaas/csi-node-driver-registrar
   newTag: v1.1.0
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -26,6 +26,8 @@ REDHAT_SUPPORT_PRODUCT_VERSION=30
 PRIVACY_POLICY_URL="https://fedoraproject.org/wiki/Legal:PrivacyPolicy"
 # docker --version
 Docker version 19.03.12, build 48a66213fe
+# ./kustomize version
+{Version:kustomize/v3.6.1 GitCommit:c97fa946d576eb6ed559f17f2ac43b3b5a8d5dbd BuildDate:2020-05-27T20:47:35Z GoOs:linux GoArch:amd64}
 ```
 ## Версионирование
 
@@ -35,7 +37,14 @@ Docker version 19.03.12, build 48a66213fe
 
 ## Артефакты
 
-Релизным артефактом этой репы является докер имадж. Для его создания необходимы установленный и настроенный докер демон - https://docs.docker.com/get-docker/ . Для сборки имаджа необходимо:
+Релизными артефактами этой репы является докер имадж и deployment конфиги для бубернетеса. При любом новом релизе необходимо обновлять kustomization.yaml и генерить бандл (например при релизе v0.5.0-CROC1):
+- в файле deployment/kubernetes/stable/kustomization.yaml изменить ```newTag``` на новый актуальный (v0.5.0-CROC1)
+- используя утилиту [kustomize](https://github.com/kubernetes-sigs/kustomize) собрать сингл-yaml-файл бандл для деплоймента:
+```
+kustomize build ./deployment/kubernetes/stable/ > ./deployment/kubernetes/stable/k_bundle.yaml
+```
+
+Для создания докер имаджа необходимы установленный и настроенный докер демон - https://docs.docker.com/get-docker/ . Для сборки имаджа необходимо:
 - находясь в руте репы выполнить:
 ```docker build -t aws-ebs-csi-driver```
 - после успешной сборки протегировать имадж:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
documentation update, k8s deployment files update
**What is this PR about? / Why do we need it?**
add new info about k_bundle file generation per new release. update k_bundle file due to v0.5.0-CROC1 release. change image tags due to images migration to c2 local docker registry
**What testing is done?** 
