### PR TITLE
Create volumes only more then 8GiB

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -78,6 +78,7 @@ const (
 	MaxTagKeyLength = 128
 	// MaxTagValueLength represents the maximum value length for a tag.
 	MaxTagValueLength = 256
+	MinTotalCapacity  = 8
 )
 
 // Defaults
@@ -448,6 +449,10 @@ func (c *cloud) CreateDisk(ctx context.Context, volumeName string, diskOptions *
 		createType = diskOptions.VolumeType
 	case VolumeTypeIO1, VolumeTypeIO2:
 		createType = diskOptions.VolumeType
+
+		if capacityGiB < MinTotalCapacity {
+			capacityGiB = MinTotalCapacity
+		}
 		iops = capacityGiB * int64(diskOptions.IOPSPerGB)
 		if iops < MinTotalIOPS {
 			iops = MinTotalIOPS

--- a/tests/e2e/pre_provsioning.go
+++ b/tests/e2e/pre_provsioning.go
@@ -37,6 +37,7 @@ const (
 	defaultVoluemType = awscloud.VolumeTypeGP2
 
 	awsAvailabilityZonesEnv = "AWS_AVAILABILITY_ZONES"
+	crocRegionEnv           = "CROC_REGION"
 
 	dummyVolumeName = "pre-provisioned"
 )
@@ -71,7 +72,7 @@ var _ = Describe("[ebs-csi-e2e] [single-az] Pre-Provisioned", func() {
 		}
 		availabilityZones := strings.Split(os.Getenv(awsAvailabilityZonesEnv), ",")
 		availabilityZone := availabilityZones[rand.Intn(len(availabilityZones))]
-		region := availabilityZone[0 : len(availabilityZone)-1]
+		region := os.Getenv(crocRegionEnv)
 
 		diskOptions := &awscloud.DiskOptions{
 			CapacityBytes:    defaultDiskSizeBytes,


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
feauture
**What is this PR about? / Why do we need it?**
Always create volumes with capacity equal or more than minimal (8GiB)
**What testing is done?** 
make test