### PR TITLE
C2DEVEL-11573: implement EBS volume resizing via CSI

### DIFF
--- a/docs/TEST.md
+++ b/docs/TEST.md
@@ -92,16 +92,13 @@ $(go env GOBIN)/ginkgo -p -nodes=32 -v --focus="\[ebs-csi-e2e\] \[single-az\]" t
 - установить ginkgo:
 - - go get github.com/onsi/ginkgo/ginkgo@v1.11.0
 - запустить e2e тесты для single az:
-- - ~/go/bin/ginkgo -v -progress --focus="\[ebs-csi-e2e\] \[single-az\]" /root/aws-ebs-csi-driver/tests/e2e -- -report-dir=./reports/ -kubeconfig=/root/.kube/config
+- - ~/go/bin/ginkgo -v -progress --focus="\\[ebs-csi-e2e\] \\[single-az\\]" /root/aws-ebs-csi-driver/tests/e2e -- -report-dir=./reports/ -kubeconfig=/root/.kube/config
 - запустить e2e тесты для multi az:
-- - ~/go/bin/ginkgo -v -progress --focus="\[ebs-csi-e2e\] \[multi-az\]" /root/aws-ebs-csi-driver/tests/e2e -- -report-dir=./reports/ -kubeconfig=/root/.kube/config
+- - ~/go/bin/ginkgo -v -progress --focus="\\[ebs-csi-e2e\] \\[multi-az\\]" /root/aws-ebs-csi-driver/tests/e2e -- -report-dir=./reports/ -kubeconfig=/root/.kube/config
 Какие тесты есть:
 
-Красные:
-- "should create a volume on demand and resize it" - не реализован метод describe-volumes-modifications
-
 Зеленые:
-- "should use a pre-defined snapshot and create pv from that"
+- "[env] should use a pre-defined snapshot and create pv from that"
 - "should create a pod, write and read to it, take a volume snapshot, and create another pod from the snapshot"
 - "should create a volume on demand with volumeType "gp2" and encryption"
 - "should create a volume on demand with volumeType "st2" and encryption"
@@ -118,12 +115,11 @@ $(go env GOBIN)/ginkgo -p -nodes=32 -v --focus="\[ebs-csi-e2e\] \[single-az\]" t
 - "should delete PV with reclaimPolicy "Delete""
 - "[env] should retain PV with reclaimPolicy "Retain""
 - "should create a deployment object, write and read to it, delete the pod and write and read to it again"
+- "should create a volume on demand and resize it"
 - "should allow for topology aware volume scheduling"
 - "[env] should allow for topology aware volume with specified zone in allowedTopologies"
 - "[env] should write and read to a pre-provisioned volume"
 - "[env] should use a pre-provisioned volume and mount it as readOnly in a pod"
 - "[env] should use a pre-provisioned volume and retain PV with reclaimPolicy "Retain""
 - "[env] should use a pre-provisioned volume and delete PV with reclaimPolicy "Delete""
-- "[env] should allow for topology aware volume with specified zone in allowedTopologies"
-- "should allow for topology aware volume scheduling"
 - "should create a volume on demand with provided mountOptions"

--- a/pkg/cloud/cloud_interface.go
+++ b/pkg/cloud/cloud_interface.go
@@ -13,6 +13,7 @@ type Cloud interface {
 	AttachDisk(ctx context.Context, volumeID string, nodeID string) (devicePath string, err error)
 	DetachDisk(ctx context.Context, volumeID string, nodeID string) (err error)
 	ResizeDisk(ctx context.Context, volumeID string, reqSize int64) (newSize int64, err error)
+	ResizeDiskC2(ctx context.Context, volumeID string, reqSize int64) (newSize int64, err error)
 	WaitForAttachmentState(ctx context.Context, volumeID, expectedState string, expectedInstance string, expectedDevice string, alreadyAssigned bool) (*ec2.VolumeAttachment, error)
 	GetDiskByName(ctx context.Context, name string, capacityBytes int64) (disk *Disk, err error)
 	GetDiskByID(ctx context.Context, volumeID string) (disk *Disk, err error)

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -468,7 +468,7 @@ func (d *controllerService) ControllerExpandVolume(ctx context.Context, req *csi
 		return nil, status.Error(codes.InvalidArgument, "After round-up, volume size exceeds the limit specified")
 	}
 
-	actualSizeGiB, err := d.cloud.ResizeDisk(ctx, volumeID, newSize)
+	actualSizeGiB, err := d.cloud.ResizeDiskC2(ctx, volumeID, newSize)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not resize volume %q: %v", volumeID, err)
 	}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -3124,7 +3124,7 @@ func TestControllerExpandVolume(t *testing.T) {
 			}
 
 			mockCloud := mocks.NewMockCloud(mockCtl)
-			mockCloud.EXPECT().ResizeDisk(gomock.Eq(ctx), gomock.Eq(tc.req.VolumeId), gomock.Any()).Return(retSizeGiB, nil).AnyTimes()
+			mockCloud.EXPECT().ResizeDiskC2(gomock.Eq(ctx), gomock.Eq(tc.req.VolumeId), gomock.Any()).Return(retSizeGiB, nil).AnyTimes()
 
 			awsDriver := controllerService{
 				cloud:         mockCloud,

--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -10,8 +10,8 @@ import (
 
 	arn "github.com/aws/aws-sdk-go/aws/arn"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
-	gomock "github.com/golang/mock/gomock"
 	cloud "github.com/c2devel/aws-ebs-csi-driver/pkg/cloud"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockCloud is a mock of Cloud interface.
@@ -228,6 +228,21 @@ func (m *MockCloud) ResizeDisk(ctx context.Context, volumeID string, reqSize int
 func (mr *MockCloudMockRecorder) ResizeDisk(ctx, volumeID, reqSize interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeDisk", reflect.TypeOf((*MockCloud)(nil).ResizeDisk), ctx, volumeID, reqSize)
+}
+
+// ResizeDiskC2 mocks base method.
+func (m *MockCloud) ResizeDiskC2(ctx context.Context, volumeID string, reqSize int64) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResizeDiskC2", ctx, volumeID, reqSize)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResizeDiskC2 indicates an expected call of ResizeDiskC2.
+func (mr *MockCloudMockRecorder) ResizeDiskC2(ctx, volumeID, reqSize interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeDiskC2", reflect.TypeOf((*MockCloud)(nil).ResizeDiskC2), ctx, volumeID, reqSize)
 }
 
 // WaitForAttachmentState mocks base method.

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -283,6 +283,10 @@ func (c *fakeCloudProvider) ResizeDisk(ctx context.Context, volumeID string, new
 	return 0, cloud.ErrNotFound
 }
 
+func (c *fakeCloudProvider) ResizeDiskC2(ctx context.Context, volumeID string, newSize int64) (int64, error) {
+	return c.ResizeDisk(ctx, volumeID, newSize)
+}
+
 type fakeMounter struct {
 	exec.Interface
 }

--- a/tests/e2e/testsuites/dynamically_provisioned_resize_volume_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_resize_volume_tester.go
@@ -47,9 +47,11 @@ func (t *DynamicallyProvisionedResizeVolumeTest) Run(client clientset.Interface,
 	pvcName := tpvc.persistentVolumeClaim.Name
 	pvc, err := client.CoreV1().PersistentVolumeClaims(namespace.Name).Get(context.TODO(), pvcName, metav1.GetOptions{})
 	By(fmt.Sprintf("Get pvc name: %v", pvc.Name))
+
 	originalSize := pvc.Spec.Resources.Requests["storage"]
+	sizeIncrementGiB := int64(8)
 	delta := resource.Quantity{}
-	delta.Set(util.GiBToBytes(1))
+	delta.Set(util.GiBToBytes(sizeIncrementGiB))
 	originalSize.Add(delta)
 	pvc.Spec.Resources.Requests["storage"] = originalSize
 


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
New feature

**What is this PR about? / Why do we need it?**
This is an implementation of volume resizing feature for C2 cloud. The original AWS method doesn't work due to EC2 API differences.

**What testing is done?**
Running unit and e2e tests. Manual resizing testing in cluster.
